### PR TITLE
ユーザー編集削除機能追加

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
   before_action :authenticate_user!
-  before_action :require_owner, only: %i[show edit update]
+  before_action :require_owner, only: %i[show edit update destroy]
 
   def index
     redirect_to root_path unless current_user&.owner?
@@ -28,6 +28,15 @@ class UsersController < ApplicationController
     else
       flash.now[:alert] = '更新に失敗しました。'
       render :edit
+    end
+  end
+
+  def destroy
+    user = User.find(params[:id])
+    if user.destroy
+      redirect_to users_path, notice: "#{user.name} を削除しました。"
+    else
+      redirect_to users_path, alert: 'ユーザーの削除に失敗しました。'
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
   before_action :authenticate_user!
-  before_action :require_owner, only: [:show]
+  before_action :require_owner, only: %i[show edit update]
 
   def index
     redirect_to root_path unless current_user&.owner?
@@ -17,6 +17,20 @@ class UsersController < ApplicationController
     @questions_with_memos = Question.includes(:memos).where(memos: { user_id: @user.id }).order(:category_id, :number)
   end
 
+  def edit
+    @user = User.find(params[:id])
+  end
+
+  def update
+    @user = User.find(params[:id])
+    if @user.update(user_params)
+      redirect_to user_path(@user), notice: 'ユーザー情報を更新しました。'
+    else
+      flash.now[:alert] = '更新に失敗しました。'
+      render :edit
+    end
+  end
+
   private
 
   def require_owner
@@ -25,5 +39,9 @@ class UsersController < ApplicationController
 
     # Owner以外は、自分の情報にしかアクセスできない
     redirect_to root_path unless current_user.id == params[:id].to_i
+  end
+
+  def user_params
+    params.require(:user).permit(:name, :email, :role)
   end
 end

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,0 +1,28 @@
+<div class="container">
+  <div class="content">
+    <h3>ユーザー編集</h3>
+    <%= form_with(model: @user, url: user_path(@user), method: :patch) do |f| %>
+      <div class="mb-3">
+        <%= f.label :name, "名前", class: "form-label" %>
+        <%= f.text_field :name, class: "form-control", required: true %>
+      </div>
+
+      <div class="mb-3">
+        <%= f.label :email, "メールアドレス", class: "form-label" %>
+        <%= f.email_field :email, class: "form-control", required: true %>
+      </div>
+
+        <div class="mb-3">
+          <%= f.label :role, "役割", class: "form-label" %><br>
+          <% if current_user.owner? %>
+            <%= f.select :role, User.roles.keys.map { |role| [role.humanize, role] }, class: "form-select" %>
+          <% else %>
+            　※役割を変更したい場合は、管理者に連絡してください。<br>
+            <%= f.text_field :role, value: @user.role.humanize, class: "form-control", readonly: true, disabled: true %>
+          <% end %>
+        </div>
+
+      <%= f.submit "更新", class: "btn btn-primary" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -20,7 +20,7 @@
             <td class="<%= role_color(user.role) %>"><%= user.role %></td>
             <td class="d-flex justify-content-evenly">
               <%= link_to "編集", edit_user_path(user.id), class: "btn btn-outline-primary" %>
-              <%= link_to '削除', "#", data: { turbo_method: :delete, turbo_confirm: "ユーザーと今までの成績も削除されます。よろしいですか？"}, class: "btn btn-outline-danger" %>
+              <%= link_to '削除', user_path(user.id), data: { turbo_method: :delete, turbo_confirm: "ユーザーと今までの成績も削除されます。よろしいですか？"}, class: "btn btn-outline-danger" %>
             </td>
           </tr>
         <% end %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -19,7 +19,7 @@
             <td><%= user.email %></td>
             <td class="<%= role_color(user.role) %>"><%= user.role %></td>
             <td class="d-flex justify-content-evenly">
-              <%= link_to "編集", "#", class: "btn btn-outline-primary" %>
+              <%= link_to "編集", edit_user_path(user.id), class: "btn btn-outline-primary" %>
               <%= link_to '削除', "#", data: { turbo_method: :delete, turbo_confirm: "ユーザーと今までの成績も削除されます。よろしいですか？"}, class: "btn btn-outline-danger" %>
             </td>
           </tr>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -3,6 +3,36 @@
     <%= link_to "←戻る", root_path, class: "btn btn-outline-warning mb-5" %>
 
     <h1><%= @user.name %>さんのマイページ</h1>
+  </div>
+
+  <div class="content">
+    <h3>ユーザー情報</h3>
+    <table class="table table-bordered align-middle">
+      <thead>
+        <tr class="text-center align-middle">
+          <th scope="col">ID</th>
+          <th scope="col">名前</th>
+          <th scope="col">Email</th>
+          <th scope="col">役割</th>
+          <th scope="col"></th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="text-center align-middle">
+          <td><%= @user.id %></td>
+          <td><%= @user.name %></td>
+          <td><%= @user.email %></td>
+          <td><%= @user.role %></td>
+          <td class="d-flex justify-content-evenly">
+            <%= link_to "編集", edit_user_path(@user.id), class: "btn btn-outline-primary" %>
+            <%= link_to '削除', "#", data: { turbo_method: :delete, turbo_confirm: "ユーザーと今までの成績も削除されます。よろしいですか？"}, class: "btn btn-outline-danger" %>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="content">
     <h3>成績履歴</h3>
     <table class="table table-striped align-middle">
       <thead>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -25,7 +25,7 @@
           <td><%= @user.role %></td>
           <td class="d-flex justify-content-evenly">
             <%= link_to "編集", edit_user_path(@user.id), class: "btn btn-outline-primary" %>
-            <%= link_to '削除', "#", data: { turbo_method: :delete, turbo_confirm: "ユーザーと今までの成績も削除されます。よろしいですか？"}, class: "btn btn-outline-danger" %>
+            <%= link_to '削除', user_path(@user.id), data: { turbo_method: :delete, turbo_confirm: "ユーザーと今までの成績も削除されます。よろしいですか？"}, class: "btn btn-outline-danger" %>
           </td>
         </tr>
       </tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,6 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :users, only: [:index, :show]
+  resources :users, only: [:index, :show, :edit, :update]
   get '/csv_upload_guidelines', to: 'home#csv_upload_guidelines'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,6 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :users, only: [:index, :show, :edit, :update]
+  resources :users, only: [:index, :show, :edit, :update, :destroy]
   get '/csv_upload_guidelines', to: 'home#csv_upload_guidelines'
 end


### PR DESCRIPTION
#36 

- Owner：ユーザー管理画面から各ユーザーの編集、削除できるようにする
- 全員：マイページに自分のユーザー情報を表示し、編集・削除できるボタンを追加
  - Owner以外は自分のroleを変更できないこととする